### PR TITLE
(Maint) count only poweredon VMs

### DIFF
--- a/lib/vmstatus/list.rb
+++ b/lib/vmstatus/list.rb
@@ -63,15 +63,17 @@ class Vmstatus::List
       puts "#{left} #{right}".colorize(color)
 
       # count for each cluster host
-      if !countcluster[clusterhost]
-        countcluster[clusterhost] = 1
-      else
-        countcluster[clusterhost] = countcluster[clusterhost] + 1
+      if vm.on? == "poweredOn" # only count when VM is on
+        if !countcluster[clusterhost]
+          countcluster[clusterhost] = 1
+        else
+          countcluster[clusterhost] = countcluster[clusterhost] + 1
+        end
       end
     end
 
     puts ""
-    puts "Cluster host count of VM"
+    puts "Cluster host count of VM that are powered on"
     countcluster.sort_by {|host, count| host}.each do |host, count|
       puts "#{host} #{count}"
     end

--- a/lib/vmstatus/summary.rb
+++ b/lib/vmstatus/summary.rb
@@ -42,14 +42,16 @@ class Vmstatus::Summary
     results.vms.each do |vm|
       clusterhost = vm.clusterhost ? vm.clusterhost : "N/A"
       # count for each cluster host
-      if !countcluster[clusterhost]
-        countcluster[clusterhost] = 1
-      else
-        countcluster[clusterhost] = countcluster[clusterhost] + 1
+      if vm.on? == "poweredOn" # only count when VM is on
+        if !countcluster[clusterhost]
+          countcluster[clusterhost] = 1
+        else
+          countcluster[clusterhost] = countcluster[clusterhost] + 1
+        end
       end
     end
 
-    puts "Cluster host count of VM"
+    puts "Cluster host count of VM that are powered on"
     countcluster.sort_by {|host, count| host}.each do |host, count|
       puts "#{host} #{count}"
     end


### PR DESCRIPTION
Before this change we could start counting the poweredOff Vms that we use
as templates for cloning VMs in vmpooler. We don't want to count these
as they do not consume CPU/memory resources